### PR TITLE
Refactor DevTrackMiddleware initialization to remove api_key parameter

### DIFF
--- a/devtrack_sdk/middleware/base.py
+++ b/devtrack_sdk/middleware/base.py
@@ -9,9 +9,8 @@ from devtrack_sdk.middleware.extractor import extract_devtrack_log_data
 class DevTrackMiddleware(BaseHTTPMiddleware):
     stats = []
 
-    def __init__(self, app, api_key: str, backend_url: str = "/__devtrack__/track"):
+    def __init__(self, app, backend_url: str = "/__devtrack__/track"):
         self.skip_paths = [backend_url, "/__devtrack__/stats"]
-        self.api_key = api_key
         self.backend_url = backend_url
         super().__init__(app)
 

--- a/examples/fastapi_example.py
+++ b/examples/fastapi_example.py
@@ -6,7 +6,7 @@ from devtrack_sdk.middleware.base import DevTrackMiddleware
 app = FastAPI()
 
 app.include_router(devtrack_router)
-app.add_middleware(DevTrackMiddleware, api_key="dummy")
+app.add_middleware(DevTrackMiddleware)
 
 
 @app.get("/")

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -10,7 +10,7 @@ from devtrack_sdk.middleware.base import DevTrackMiddleware
 def app_with_middleware():
     app = FastAPI()
     app.include_router(devtrack_router)
-    app.add_middleware(DevTrackMiddleware, api_key="test-key")
+    app.add_middleware(DevTrackMiddleware)
 
     @app.get("/")
     async def root():


### PR DESCRIPTION
- Updated the DevTrackMiddleware class to eliminate the api_key parameter from its constructor.
- Adjusted example usage in fastapi_example.py and test_middleware.py to reflect this change.