### PR TITLE
Fix: Resolve DuckDB lock conflicts between CLI commands and running application

### DIFF
--- a/devtrack_sdk/controller/devtrack_routes.py
+++ b/devtrack_sdk/controller/devtrack_routes.py
@@ -18,7 +18,7 @@ async def stats(
     status_code: Optional[int] = Query(None, description="Filter by status code"),
 ):
     """Get DevTrack statistics and logs from DuckDB."""
-    db = get_db()
+    db = get_db(read_only=True)
 
     try:
         # Get summary stats
@@ -62,7 +62,7 @@ async def delete_logs(
     ),
 ):
     """Delete logs from the database with various filtering options."""
-    db = get_db()
+    db = get_db(read_only=False)
 
     try:
         deleted_count = 0
@@ -105,7 +105,7 @@ async def delete_logs(
 @router.delete("/__devtrack__/logs/{log_id}", include_in_schema=False)
 async def delete_log_by_id(log_id: int):
     """Delete a specific log by its ID."""
-    db = get_db()
+    db = get_db(read_only=False)
 
     try:
         deleted_count = db.delete_logs_by_id(log_id)
@@ -131,7 +131,7 @@ async def metrics_traffic(
     hours: int = Query(24, description="Number of hours to look back"),
 ):
     """Get traffic metrics over time."""
-    db = get_db()
+    db = get_db(read_only=True)
     try:
         traffic_data = db.get_traffic_over_time(hours=hours)
         return {"traffic": traffic_data}
@@ -144,7 +144,7 @@ async def metrics_errors(
     hours: int = Query(24, description="Number of hours to look back"),
 ):
     """Get error trends and top failing routes."""
-    db = get_db()
+    db = get_db(read_only=True)
     try:
         error_data = db.get_error_trends(hours=hours)
         return error_data
@@ -157,7 +157,7 @@ async def metrics_perf(
     hours: int = Query(24, description="Number of hours to look back"),
 ):
     """Get performance metrics (p50/p95/p99 latency)."""
-    db = get_db()
+    db = get_db(read_only=True)
     try:
         perf_data = db.get_performance_metrics(hours=hours)
         return perf_data
@@ -170,7 +170,7 @@ async def consumers(
     hours: int = Query(24, description="Number of hours to look back"),
 ):
     """Get consumer segmentation data."""
-    db = get_db()
+    db = get_db(read_only=True)
     try:
         segments_data = db.get_consumer_segments(hours=hours)
         return segments_data

--- a/devtrack_sdk/django_views.py
+++ b/devtrack_sdk/django_views.py
@@ -16,7 +16,7 @@ def get_db_instance() -> DevTrackDB:
     """Get the database instance from middleware"""
     if DevTrackDjangoMiddleware._db_instance is None:
         db_path = getattr(settings, "DEVTRACK_DB_PATH", "devtrack_logs.db")
-        DevTrackDjangoMiddleware._db_instance = DevTrackDB(db_path)
+        DevTrackDjangoMiddleware._db_instance = DevTrackDB(db_path, read_only=False)
     return DevTrackDjangoMiddleware._db_instance
 
 

--- a/devtrack_sdk/management/commands/devtrack_reset.py
+++ b/devtrack_sdk/management/commands/devtrack_reset.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
                 return
 
         try:
-            db = DevTrackDB(db_path)
+            db = DevTrackDB(db_path, read_only=False)
             deleted_count = db.delete_all_logs()
 
             self.stdout.write(

--- a/devtrack_sdk/management/commands/devtrack_stats.py
+++ b/devtrack_sdk/management/commands/devtrack_stats.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
         output_format = options["format"]
 
         try:
-            db = DevTrackDB(db_path)
+            db = DevTrackDB(db_path, read_only=True)
             stats = db.get_stats_summary()
             recent_logs = db.get_all_logs(limit=limit)
 

--- a/devtrack_sdk/middleware/base.py
+++ b/devtrack_sdk/middleware/base.py
@@ -50,7 +50,7 @@ class DevTrackMiddleware(BaseHTTPMiddleware):
 
         try:
             log_data = await extract_devtrack_log_data(request, response, start_time)
-            db = self.db_instance if self.db_instance else get_db()
+            db = self.db_instance if self.db_instance else get_db(read_only=False)
             db.insert_log(log_data)
         except Exception as e:
             print(f"[DevTrackMiddleware] Logging error: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,10 @@ devtrack = "devtrack_sdk.cli:app"
 
 [tool.isort]
 profile = "black"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+norecursedirs = [".git", ".venv", "venv", "__pycache__", "*.egg"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+"""
+Pytest configuration for DevTrack SDK tests
+"""
+
+# Ignore test_wsgi.py during pytest collection
+# It's a WSGI configuration file, not a test file
+collect_ignore = ["test_wsgi.py"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,37 @@
 Pytest configuration for DevTrack SDK tests
 """
 
+from unittest.mock import patch
+
+import pytest
+import requests
+
 # Ignore test_wsgi.py during pytest collection
 # It's a WSGI configuration file, not a test file
 collect_ignore = ["test_wsgi.py"]
+
+
+@pytest.fixture(autouse=True)
+def mock_network_requests():
+    """
+    Automatically mock network requests to prevent hanging in CI.
+    This ensures detect_devtrack_endpoint() doesn't make real network calls.
+    Tests that need specific network behavior should override these mocks.
+    """
+    # Mock requests.get/delete to raise RequestException by default
+    # This makes detect_devtrack_endpoint() try all URLs (fast with 0.5s timeout)
+    # and then prompt. We mock typer.prompt/confirm to avoid hanging on user input.
+    # Tests that need specific behavior will override these mocks.
+    with patch(
+        "requests.get", side_effect=requests.RequestException("Mocked network error")
+    ):
+        with patch(
+            "requests.delete",
+            side_effect=requests.RequestException("Mocked network error"),
+        ):
+            # Mock typer prompts with sensible defaults to avoid hanging
+            # Tests that test prompt behavior will override these
+            with patch("typer.prompt", return_value="localhost"):
+                with patch("typer.confirm", return_value=False):
+                    with patch("typer.echo"):  # Suppress echo output in tests
+                        yield

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,32 @@
+import json
+import os
+import tempfile
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import requests
 from typer.testing import CliRunner
 
 from devtrack_sdk.cli import app, detect_devtrack_endpoint
+from devtrack_sdk.database import DevTrackDB, init_db
 
 runner = CliRunner()
+
+
+def create_test_db(db_path=None):
+    """Helper to create a test database file."""
+    if db_path is None:
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+            db_path = tmp.name
+            os.unlink(db_path)  # Remove empty file
+
+    # Ensure file doesn't exist
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+
+    # Create proper database
+    db = init_db(db_path, read_only=False)
+    return db_path, db
 
 
 def test_version():
@@ -246,3 +267,871 @@ def test_stat_command_empty_stats():
             assert (
                 "No request stats found yet" in result.output
             ), "Empty stats message mismatch"
+
+
+# ========== INIT COMMAND TESTS ==========
+
+
+def test_init_new_database():
+    """Test initializing a new database."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file, let DuckDB create it
+
+    try:
+        result = runner.invoke(app, ["init", "--db-path", db_path])
+        assert result.exit_code == 0, "Init command failed"
+        assert (
+            "✅ DevTrack database initialized" in result.output
+            or "initialized" in result.output.lower()
+        )
+        assert os.path.exists(db_path), "Database file not created"
+
+        # Verify tables exist
+        db = DevTrackDB(db_path, read_only=True)
+        assert db.tables_exist(), "Tables not created"
+        db.close()
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_init_existing_database():
+    """Test init on existing database without --force."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        # Create database first using init_db
+        from devtrack_sdk.database import init_db
+
+        init_db(db_path, read_only=False).close()
+
+        result = runner.invoke(app, ["init", "--db-path", db_path], input="n\n")
+        assert result.exit_code == 0, "Init on existing DB should succeed"
+        assert "already initialized" in result.output or "Overwrite" in result.output
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_init_with_force():
+    """Test init with --force flag."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        # Create database with some data
+        db = init_db(db_path, read_only=False)
+        db.insert_log(
+            {
+                "path": "/test",
+                "method": "GET",
+                "status_code": 200,
+                "duration_ms": 100,
+                "timestamp": "2024-01-01T00:00:00",
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.close()
+
+        result = runner.invoke(app, ["init", "--db-path", db_path, "--force"])
+        # Should succeed (may use API or direct DB)
+        assert result.exit_code in [0, 1], "Init with force should handle gracefully"
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_init_with_force_via_api():
+    """Test init --force using HTTP API."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        # Create database
+        db = init_db(db_path, read_only=False)
+        db.close()
+
+        mock_delete_response = MagicMock(
+            status_code=200, json=MagicMock(return_value={"deleted_count": 5})
+        )
+
+        with patch(
+            "devtrack_sdk.cli.detect_devtrack_endpoint",
+            return_value="http://localhost:8000/__devtrack__/stats",
+        ):
+            with patch("requests.delete", return_value=mock_delete_response):
+                result = runner.invoke(app, ["init", "--db-path", db_path, "--force"])
+                assert result.exit_code == 0, "Init with force via API failed"
+                assert "via API" in result.output or "reset" in result.output.lower()
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_init_locked_database():
+    """Test init when database is locked."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        # Create database first
+        db = init_db(db_path, read_only=False)
+        db.close()
+
+        # Now simulate lock error when trying to init again
+        import duckdb
+
+        lock_error = duckdb.IOException("IO Error: Could not set lock on file")
+
+        with patch("devtrack_sdk.cli.init_db", side_effect=lock_error):
+            result = runner.invoke(app, ["init", "--db-path", db_path])
+            # Should handle lock gracefully
+            assert "lock" in result.output.lower() or result.exit_code == 0
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+# ========== RESET COMMAND TESTS ==========
+
+
+def test_reset_missing_database():
+    """Test reset on non-existent database."""
+    result = runner.invoke(app, ["reset", "--db-path", "nonexistent.db"])
+    assert result.exit_code == 0, "Reset on missing DB should exit gracefully"
+    assert "does not exist" in result.output
+
+
+def test_reset_with_confirmation():
+    """Test reset with confirmation prompt."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.insert_log(
+            {
+                "path": "/test",
+                "method": "GET",
+                "status_code": 200,
+                "duration_ms": 100,
+                "timestamp": "2024-01-01T00:00:00",
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.close()
+
+        result = runner.invoke(app, ["reset", "--db-path", db_path], input="n\n")
+        assert result.exit_code == 0, "Reset cancelled should exit gracefully"
+        assert (
+            "cancelled" in result.output.lower() or "Reset cancelled" in result.output
+        )
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_reset_with_yes_flag():
+    """Test reset with --yes flag (skip confirmation)."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.insert_log(
+            {
+                "path": "/test",
+                "method": "GET",
+                "status_code": 200,
+                "duration_ms": 100,
+                "timestamp": "2024-01-01T00:00:00",
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.close()
+
+        result = runner.invoke(app, ["reset", "--db-path", db_path, "--yes"])
+        assert result.exit_code == 0, "Reset with --yes failed"
+        assert "reset" in result.output.lower() or "deleted" in result.output.lower()
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_reset_via_api():
+    """Test reset using HTTP API."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.close()
+
+        mock_delete_response = MagicMock(
+            status_code=200, json=MagicMock(return_value={"deleted_count": 10})
+        )
+
+        with patch(
+            "devtrack_sdk.cli.detect_devtrack_endpoint",
+            return_value="http://localhost:8000/__devtrack__/stats",
+        ):
+            with patch("requests.delete", return_value=mock_delete_response):
+                result = runner.invoke(app, ["reset", "--db-path", db_path, "--yes"])
+                assert result.exit_code == 0, "Reset via API failed"
+                assert "via API" in result.output or "deleted" in result.output.lower()
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_reset_locked_database():
+    """Test reset when database is locked."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.close()
+
+        # Simulate lock error
+        import duckdb
+
+        lock_error = duckdb.IOException("IO Error: Could not set lock on file")
+
+        with patch("devtrack_sdk.cli.DevTrackDB") as mock_db:
+            mock_instance = MagicMock()
+            mock_instance.delete_all_logs.side_effect = lock_error
+            mock_db.return_value = mock_instance
+
+            with patch(
+                "devtrack_sdk.cli.detect_devtrack_endpoint", side_effect=Exception
+            ):
+                result = runner.invoke(app, ["reset", "--db-path", db_path, "--yes"])
+                assert result.exit_code == 1, "Reset on locked DB should fail"
+                assert (
+                    "lock" in result.output.lower() or "locked" in result.output.lower()
+                )
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+# ========== EXPORT COMMAND TESTS ==========
+
+
+def test_export_missing_database():
+    """Test export on non-existent database."""
+    result = runner.invoke(app, ["export", "--db-path", "nonexistent.db"])
+    assert result.exit_code == 1, "Export on missing DB should fail"
+    assert "does not exist" in result.output
+
+
+def test_export_json_format():
+    """Test export to JSON format."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp_db:
+        db_path = tmp_db.name
+        os.unlink(db_path)  # Remove empty file
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp_out:
+        out_path = tmp_out.name
+        os.unlink(out_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.insert_log(
+            {
+                "path": "/api/test",
+                "path_pattern": "/api/test",  # Required field
+                "method": "GET",
+                "status_code": 200,
+                "duration_ms": 100,
+                "timestamp": "2024-01-01T00:00:00",
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.close()
+
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                "--db-path",
+                db_path,
+                "--output-file",
+                out_path,
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, f"Export to JSON failed: {result.output}"
+        assert os.path.exists(out_path), "Output file not created"
+
+        with open(out_path) as f:
+            data = json.load(f)
+            assert "entries" in data or "export_timestamp" in data
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+def test_export_csv_format():
+    """Test export to CSV format."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp_db:
+        db_path = tmp_db.name
+        os.unlink(db_path)  # Remove empty file
+
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp_out:
+        out_path = tmp_out.name
+        os.unlink(out_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.insert_log(
+            {
+                "path": "/api/test",
+                "method": "GET",
+                "status_code": 200,
+                "duration_ms": 100,
+                "timestamp": "2024-01-01T00:00:00",
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.close()
+
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                "--db-path",
+                db_path,
+                "--output-file",
+                out_path,
+                "--format",
+                "csv",
+            ],
+        )
+        assert result.exit_code == 0, "Export to CSV failed"
+        assert os.path.exists(out_path), "Output file not created"
+
+        with open(out_path) as f:
+            content = f.read()
+            assert "path" in content or "method" in content
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+def test_export_with_filters():
+    """Test export with path pattern and status code filters."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp_db:
+        db_path = tmp_db.name
+        os.unlink(db_path)  # Remove empty file
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp_out:
+        out_path = tmp_out.name
+        os.unlink(out_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.insert_log(
+            {
+                "path": "/api/test",
+                "method": "GET",
+                "status_code": 200,
+                "duration_ms": 100,
+                "timestamp": "2024-01-01T00:00:00",
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.insert_log(
+            {
+                "path": "/api/other",
+                "method": "POST",
+                "status_code": 404,
+                "duration_ms": 50,
+                "timestamp": "2024-01-01T00:00:00",
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.close()
+
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                "--db-path",
+                db_path,
+                "--output-file",
+                out_path,
+                "--path-pattern",
+                "/api/test",
+                "--status-code",
+                "200",
+            ],
+        )
+        assert result.exit_code == 0, "Export with filters failed"
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+def test_export_empty_database():
+    """Test export from empty database."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp_db:
+        db_path = tmp_db.name
+        os.unlink(db_path)  # Remove empty file
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp_out:
+        out_path = tmp_out.name
+        os.unlink(out_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.close()
+
+        result = runner.invoke(
+            app, ["export", "--db-path", db_path, "--output-file", out_path]
+        )
+        assert result.exit_code == 0, "Export from empty DB should succeed"
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+def test_export_with_limit():
+    """Test export with limit option."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp_db:
+        db_path = tmp_db.name
+        os.unlink(db_path)  # Remove empty file
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp_out:
+        out_path = tmp_out.name
+        os.unlink(out_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        for i in range(5):
+            db.insert_log(
+                {
+                    "path": f"/api/test{i}",
+                    "path_pattern": f"/api/test{i}",  # Required field
+                    "method": "GET",
+                    "status_code": 200,
+                    "duration_ms": 100,
+                    "timestamp": "2024-01-01T00:00:00",
+                    "client_ip": "127.0.0.1",
+                    "user_agent": "test",
+                }
+            )
+        db.close()
+
+        result = runner.invoke(
+            app,
+            ["export", "--db-path", db_path, "--output-file", out_path, "--limit", "2"],
+        )
+        assert result.exit_code == 0, f"Export with limit failed: {result.output}"
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+# ========== QUERY COMMAND TESTS ==========
+
+
+def test_query_missing_database():
+    """Test query on non-existent database."""
+    result = runner.invoke(app, ["query", "--db-path", "nonexistent.db"])
+    assert result.exit_code == 1, "Query on missing DB should fail"
+    assert "does not exist" in result.output
+
+
+def test_query_empty_database():
+    """Test query on empty database."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.close()
+
+        result = runner.invoke(app, ["query", "--db-path", db_path])
+        assert result.exit_code == 0, "Query on empty DB should succeed"
+        assert "No logs found" in result.output or "No logs" in result.output
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_query_with_path_pattern():
+    """Test query with path pattern filter."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.insert_log(
+            {
+                "path": "/api/test",
+                # Required - get_logs_by_path searches path_pattern column
+                "path_pattern": "/api/test",
+                "method": "GET",
+                "status_code": 200,
+                "duration_ms": 100,
+                "timestamp": "2024-01-01T00:00:00",
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.close()
+
+        result = runner.invoke(
+            app, ["query", "--db-path", db_path, "--path-pattern", "/api/test"]
+        )
+        assert result.exit_code == 0, "Query with path pattern failed"
+        # get_logs_by_path searches path_pattern column, so it should find the log
+        assert (
+            "No logs found" not in result.output
+        ), f"Expected to find logs but got: {result.output}"
+        assert "/api/test" in result.output or "test" in result.output.lower()
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_query_with_status_code():
+    """Test query with status code filter."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.insert_log(
+            {
+                "path": "/api/test",
+                "method": "GET",
+                "status_code": 404,
+                "duration_ms": 100,
+                "timestamp": "2024-01-01T00:00:00",
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.close()
+
+        result = runner.invoke(
+            app, ["query", "--db-path", db_path, "--status-code", "404"]
+        )
+        assert result.exit_code == 0, "Query with status code failed"
+        assert "404" in result.output
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_query_with_method():
+    """Test query with HTTP method filter."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.insert_log(
+            {
+                "path": "/api/test",
+                "method": "POST",
+                "status_code": 200,
+                "duration_ms": 100,
+                "timestamp": "2024-01-01T00:00:00",
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.close()
+
+        result = runner.invoke(app, ["query", "--db-path", db_path, "--method", "POST"])
+        assert result.exit_code == 0, "Query with method failed"
+        assert "POST" in result.output
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_query_with_days():
+    """Test query with days filter."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.insert_log(
+            {
+                "path": "/api/test",
+                "method": "GET",
+                "status_code": 200,
+                "duration_ms": 100,
+                "timestamp": datetime.now().isoformat(),
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.close()
+
+        result = runner.invoke(app, ["query", "--db-path", db_path, "--days", "7"])
+        assert result.exit_code == 0, "Query with days failed"
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_query_with_verbose():
+    """Test query with verbose flag."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.insert_log(
+            {
+                "path": "/api/test",
+                "method": "GET",
+                "status_code": 200,
+                "duration_ms": 100,
+                "timestamp": "2024-01-01T00:00:00",
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.close()
+
+        result = runner.invoke(app, ["query", "--db-path", db_path, "--verbose"])
+        assert result.exit_code == 0, "Query with verbose failed"
+        assert "Path:" in result.output or "Method:" in result.output
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_query_with_limit():
+    """Test query with limit option."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        for i in range(5):
+            db.insert_log(
+                {
+                    "path": f"/api/test{i}",
+                    "method": "GET",
+                    "status_code": 200,
+                    "duration_ms": 100,
+                    "timestamp": "2024-01-01T00:00:00",
+                    "client_ip": "127.0.0.1",
+                    "user_agent": "test",
+                }
+            )
+        db.close()
+
+        result = runner.invoke(app, ["query", "--db-path", db_path, "--limit", "2"])
+        assert result.exit_code == 0, "Query with limit failed"
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+# ========== STAT COMMAND TESTS (Additional) ==========
+
+
+def test_stat_command_database_mode():
+    """Test stat command using database (not endpoint)."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.insert_log(
+            {
+                "path": "/api/test",
+                "method": "GET",
+                "status_code": 200,
+                "duration_ms": 100,
+                "timestamp": "2024-01-01T00:00:00",
+                "client_ip": "127.0.0.1",
+                "user_agent": "test",
+            }
+        )
+        db.close()
+
+        result = runner.invoke(app, ["stat", "--db-path", db_path], input="n\n")
+        assert result.exit_code == 0, "Stat with DB mode failed"
+        assert "📊 DevTrack Stats CLI" in result.output
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_stat_command_missing_database():
+    """Test stat command with missing database."""
+    result = runner.invoke(app, ["stat", "--db-path", "nonexistent.db"])
+    assert result.exit_code == 1, "Stat on missing DB should fail"
+    assert "does not exist" in result.output
+
+
+def test_stat_command_empty_database():
+    """Test stat command with empty database."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.close()
+
+        result = runner.invoke(app, ["stat", "--db-path", db_path], input="n\n")
+        assert result.exit_code == 0, "Stat on empty DB should succeed"
+        assert "No request stats found" in result.output
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+# ========== HEALTH COMMAND TESTS ==========
+
+
+def test_health_command_database_only():
+    """Test health command checking database only."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+        os.unlink(db_path)  # Remove empty file
+
+    try:
+        db = init_db(db_path, read_only=False)
+        db.close()
+
+        result = runner.invoke(app, ["health", "--db-path", db_path])
+        assert result.exit_code in [0, 1], "Health check should complete"
+        assert "Health Check" in result.output or "Healthy" in result.output
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_health_command_missing_database():
+    """Test health command with missing database."""
+    result = runner.invoke(app, ["health", "--db-path", "nonexistent.db"])
+    # Health check doesn't fail on missing DB, it just reports it
+    assert result.exit_code in [0, 1], "Health check should complete"
+    assert (
+        "Not Found" in result.output
+        or "does not exist" in result.output
+        or "⚠️" in result.output
+    )
+
+
+def test_health_command_with_endpoint():
+    """Test health command with endpoint check."""
+    mock_response = MagicMock(status_code=200)
+
+    with patch(
+        "devtrack_sdk.cli.detect_devtrack_endpoint",
+        return_value="http://localhost:8000/__devtrack__/stats",
+    ):
+        with patch("requests.get", return_value=mock_response):
+            with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+                db_path = tmp.name
+                os.unlink(db_path)  # Remove empty file
+            try:
+                db = init_db(db_path, read_only=False)
+                db.close()
+
+                result = runner.invoke(
+                    app, ["health", "--db-path", db_path, "--endpoint"]
+                )
+                assert result.exit_code in [
+                    0,
+                    1,
+                ], "Health with endpoint should complete"
+            finally:
+                if os.path.exists(db_path):
+                    os.unlink(db_path)
+
+
+def test_health_command_endpoint_unreachable():
+    """Test health command when endpoint is unreachable."""
+    with patch(
+        "devtrack_sdk.cli.detect_devtrack_endpoint",
+        return_value="http://localhost:8000/__devtrack__/stats",
+    ):
+        with patch(
+            "requests.get", side_effect=requests.RequestException("Connection failed")
+        ):
+            with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+                db_path = tmp.name
+                os.unlink(db_path)  # Remove empty file
+            try:
+                db = init_db(db_path, read_only=False)
+                db.close()
+
+                result = runner.invoke(
+                    app, ["health", "--db-path", db_path, "--endpoint"]
+                )
+                assert (
+                    result.exit_code == 1
+                ), "Health with unreachable endpoint should fail"
+                assert "Unreachable" in result.output or "Unhealthy" in result.output
+            finally:
+                if os.path.exists(db_path):
+                    os.unlink(db_path)
+
+
+# ========== HELP COMMAND TESTS ==========
+
+
+def test_help_command():
+    """Test help command."""
+    result = runner.invoke(app, ["help"])
+    assert result.exit_code == 0, "Help command failed"
+    assert "DevTrack CLI" in result.output or "Available Commands" in result.output
+
+
+def test_version_command_detailed():
+    """Test version command shows all information."""
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0, "Version command failed"
+    assert "DevTrack SDK" in result.output
+    assert "Version" in result.output or "Framework Support" in result.output


### PR DESCRIPTION
## Fix: Resolve DuckDB lock conflicts between CLI commands and running application

### Problem
CLI commands (`stat`, `query`, `init`) fail when the database is locked by a running application due to DuckDB's file-level locking mechanism.

### Solution
- Added HTTP API fallback for `stat`, `query`, and `init` commands when database lock is detected
- `init` command now checks database status via API before prompting for overwrite
- Improved error messages with lock detection and process information
- Fixed `--force` flag to properly exit after successful API reset

### Changes
- `cli.py`: Added API fallback logic with `check_db_initialized_via_api()` helper
- `database.py`: Improved connection handling for read/write mode transitions
- Enhanced user experience with clear messaging when database is locked

### Testing
All CLI commands tested with running application to verify graceful fallback behavior.