### PR TITLE
Make framework dependencies optional and expand Django compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        django-version:
+          - "django>=4.2,<4.3"
+          - "django>=5.2,<5.3"
 
     steps:
       - uses: actions/checkout@v4
@@ -20,8 +26,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install pytest flake8
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install "${{ matrix.django-version }}"
+          pip install flake8
 
       - name: Run flake8
         run: flake8 .

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@
 
 ### 1. Install DevTrack SDK
 ```bash
-pip install devtrack-sdk
+# FastAPI
+pip install "devtrack-sdk[fastapi]"
+
+# Django
+pip install "devtrack-sdk[django]"
 ```
 
 ### 2. Choose Your Framework
@@ -133,7 +137,17 @@ devtrack monitor --interval 3
 
 ### Install from PyPI
 ```bash
+# Core CLI/database only
 pip install devtrack-sdk
+
+# FastAPI integration
+pip install "devtrack-sdk[fastapi]"
+
+# Django integration
+pip install "devtrack-sdk[django]"
+
+# Both integrations
+pip install "devtrack-sdk[all]"
 ```
 
 ### Install from Source
@@ -144,13 +158,12 @@ pip install -e .
 ```
 
 ### Dependencies
-- `fastapi>=0.90` - FastAPI framework support
-- `django>=4.0.0` - Django framework support
-- `httpx>=0.24` - HTTP client for CLI
-- `starlette>=0.22` - ASGI framework
-- `rich>=13.3` - Rich CLI interface
-- `typer>=0.9` - CLI framework
 - `duckdb>=1.1.0` - Embedded database
+- `rich>=13.3` - Rich CLI interface
+- `requests>=2.31` - HTTP client for CLI
+- `typer>=0.9` - CLI framework
+- `fastapi>=0.90` - Optional FastAPI framework support via `devtrack-sdk[fastapi]`
+- `django>=4.0.0` - Optional Django framework support via `devtrack-sdk[django]`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ devtrack monitor --interval 3
 ### Prerequisites
 - Python 3.10 or higher
 - FastAPI or Django application
+- Django integration is tested with Django 5.2 and remains compatible with Django 4.0+
 
 ### Install from PyPI
 ```bash
@@ -163,7 +164,7 @@ pip install -e .
 - `requests>=2.31` - HTTP client for CLI
 - `typer>=0.9` - CLI framework
 - `fastapi>=0.90` - Optional FastAPI framework support via `devtrack-sdk[fastapi]`
-- `django>=4.0.0` - Optional Django framework support via `devtrack-sdk[django]`
+- `django>=4.0.0` - Optional Django framework support via `devtrack-sdk[django]` (tested with Django 5.2)
 
 ---
 

--- a/devtrack_sdk/__init__.py
+++ b/devtrack_sdk/__init__.py
@@ -1,12 +1,40 @@
-# DevTrack SDK - Request tracking middleware for FastAPI and Django
+"""DevTrack SDK - Request tracking middleware for FastAPI and Django."""
 
-from devtrack_sdk.controller import router as devtrack_router
-from devtrack_sdk.django_middleware import DevTrackDjangoMiddleware
-from devtrack_sdk.django_urls import devtrack_cbv_urlpatterns, devtrack_urlpatterns
-from devtrack_sdk.django_views import DevTrackView, stats_view, track_view
-from devtrack_sdk.middleware import DevTrackMiddleware
+from importlib import import_module
+
+from devtrack_sdk.__version__ import __version__
+
+_LAZY_EXPORTS = {
+    "DevTrackMiddleware": ("devtrack_sdk.middleware", "DevTrackMiddleware"),
+    "devtrack_router": ("devtrack_sdk.controller", "router"),
+    "DevTrackDjangoMiddleware": (
+        "devtrack_sdk.django_middleware",
+        "DevTrackDjangoMiddleware",
+    ),
+    "track_view": ("devtrack_sdk.django_views", "track_view"),
+    "stats_view": ("devtrack_sdk.django_views", "stats_view"),
+    "DevTrackView": ("devtrack_sdk.django_views", "DevTrackView"),
+    "devtrack_urlpatterns": ("devtrack_sdk.django_urls", "devtrack_urlpatterns"),
+    "devtrack_cbv_urlpatterns": (
+        "devtrack_sdk.django_urls",
+        "devtrack_cbv_urlpatterns",
+    ),
+}
+
+
+def __getattr__(name):
+    if name not in _LAZY_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_name, attribute_name = _LAZY_EXPORTS[name]
+    module = import_module(module_name)
+    attribute = getattr(module, attribute_name)
+    globals()[name] = attribute
+    return attribute
+
 
 __all__ = [
+    "__version__",
     # FastAPI
     "DevTrackMiddleware",
     "devtrack_router",

--- a/docs/django_integration.md
+++ b/docs/django_integration.md
@@ -10,6 +10,8 @@ This guide shows you how to integrate DevTrack SDK v0.4.0 with your Django appli
 pip install "devtrack-sdk[django]"
 ```
 
+DevTrack SDK is tested with Django 5.2 while keeping the Django dependency broad (`django>=4.0.0`) so existing Django 5.2 apps are not downgraded.
+
 ### 2. Initialize Database
 
 Initialize the DuckDB database for persistent log storage:

--- a/docs/django_integration.md
+++ b/docs/django_integration.md
@@ -7,7 +7,7 @@ This guide shows you how to integrate DevTrack SDK v0.4.0 with your Django appli
 ### 1. Installation
 
 ```bash
-pip install devtrack-sdk
+pip install "devtrack-sdk[django]"
 ```
 
 ### 2. Initialize Database
@@ -576,7 +576,7 @@ LOG_LEVEL=INFO
 
 2. **Import errors**
    ```bash
-   pip install devtrack-sdk
+   pip install "devtrack-sdk[django]"
    ```
 
 3. **Permission errors**

--- a/docs/fastapi_integration.md
+++ b/docs/fastapi_integration.md
@@ -7,7 +7,7 @@ This guide shows you how to integrate DevTrack SDK v0.4.0 with your FastAPI appl
 ### 1. Installation
 
 ```bash
-pip install devtrack-sdk
+pip install "devtrack-sdk[fastapi]"
 ```
 
 ### 2. Initialize Database
@@ -456,7 +456,7 @@ LOG_LEVEL=INFO
 
 2. **Import errors**
    ```bash
-   pip install devtrack-sdk
+   pip install "devtrack-sdk[fastapi]"
    ```
 
 3. **Permission errors**

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,11 @@
 ### 1. Install DevTrack SDK
 
 ```bash
-pip install devtrack-sdk
+# FastAPI
+pip install "devtrack-sdk[fastapi]"
+
+# Django
+pip install "devtrack-sdk[django]"
 ```
 
 ### 2. Choose Your Framework

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,8 @@ pip install "devtrack-sdk[fastapi]"
 pip install "devtrack-sdk[django]"
 ```
 
+Django support is tested with Django 5.2 while remaining compatible with Django 4.0+.
+
 ### 2. Choose Your Framework
 
 #### FastAPI Integration

--- a/examples/devtrack_example/devtrack_example/settings.py
+++ b/examples/devtrack_example/devtrack_example/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = "django-insecure-q8k#9bd7xoxz5x1e)6mm@m9@#t-oiuky2$vveryh)=e+-)l^9x
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Framework :: FastAPI",
     "Framework :: Django",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,31 @@ classifiers = [
     "Operating System :: OS Independent"
 ]
 dependencies = [
-    "fastapi>=0.90",
-    "django>=4.0.0",
-    "httpx>=0.24",
-    "starlette>=0.22",
     "rich>=13.3",
+    "requests>=2.31",
     "typer>=0.9",
     "duckdb>=1.1.0"
+]
+
+[project.optional-dependencies]
+fastapi = [
+    "fastapi>=0.90"
+]
+django = [
+    "django>=4.0.0"
+]
+all = [
+    "fastapi>=0.90",
+    "django>=4.0.0"
+]
+dev = [
+    "django>=4.0.0",
+    "fastapi>=0.90",
+    "httpx>=0.24",
+    "pytest>=8.0",
+    "pytest-mock>=3.12",
+    "tomli>=2.0; python_version < '3.11'",
+    "uvicorn>=0.34"
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ starlette==0.46.2
 typer==0.15.4
 typing-inspection==0.4.0
 typing_extensions==4.13.2
+tomli==2.2.1; python_version < "3.11"
 uvicorn==0.34.2
 pytest==8.2.2
 pytest-mock==3.12.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="devtrack-sdk",
-    version="0.4.1",
+    version="0.4.2",
     description=(
         "Middleware-based API analytics and observability tool for FastAPI and Django"
     ),
@@ -20,7 +20,26 @@ setup(
         ],
     },
     include_package_data=True,
-    install_requires=["fastapi", "httpx", "starlette", "django>=4.0.0"],
+    install_requires=[
+        "duckdb>=1.1.0",
+        "requests>=2.31",
+        "rich>=13.3",
+        "typer>=0.9",
+    ],
+    extras_require={
+        "fastapi": ["fastapi>=0.90"],
+        "django": ["django>=4.0.0"],
+        "all": ["fastapi>=0.90", "django>=4.0.0"],
+        "dev": [
+            "django>=4.0.0",
+            "fastapi>=0.90",
+            "httpx>=0.24",
+            "pytest>=8.0",
+            "pytest-mock>=3.12",
+            "tomli>=2.0; python_version < '3.11'",
+            "uvicorn>=0.34",
+        ],
+    },
     python_requires=">=3.10",
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Framework :: Django",
+        "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.2",
         "Framework :: FastAPI",
     ],
     entry_points={

--- a/tests/test_django_compatibility.py
+++ b/tests/test_django_compatibility.py
@@ -1,0 +1,62 @@
+"""
+Compatibility tests for supported Django versions.
+"""
+
+import os
+from datetime import datetime, timezone
+
+import django
+from django import VERSION as DJANGO_VERSION
+from django.apps import apps
+from django.conf import settings
+from django.test import RequestFactory
+
+from devtrack_sdk.django_middleware import DevTrackDjangoMiddleware
+from devtrack_sdk.django_urls import devtrack_urlpatterns
+from devtrack_sdk.django_views import stats_view
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_settings")
+if not apps.ready:
+    django.setup()
+
+
+def test_django_runtime_is_in_supported_ci_matrix():
+    """Verify CI exercises the declared supported Django versions."""
+    assert DJANGO_VERSION[:2] in {(4, 2), (5, 2)}
+
+
+def test_django_52_middleware_and_urls_load_with_configured_settings():
+    """Verify Django 5.2 can load DevTrack middleware, views, and URL patterns."""
+    assert settings.configured
+    assert DevTrackDjangoMiddleware.__module__ == "devtrack_sdk.django_middleware"
+    assert callable(stats_view)
+    assert {pattern.name for pattern in devtrack_urlpatterns} >= {
+        "devtrack_track",
+        "devtrack_stats",
+        "devtrack_dashboard",
+    }
+
+
+def test_django_52_request_factory_extracts_request_data(tmp_path):
+    """Verify request metadata extraction works with Django 5.2 request objects."""
+    db_path = str(tmp_path / "devtrack_django_52.db")
+    middleware = DevTrackDjangoMiddleware(lambda request: None, db_path=db_path)
+    try:
+        request = RequestFactory().get(
+            "/api/widgets?limit=10", HTTP_USER_AGENT="pytest"
+        )
+        response = type("Response", (), {"status_code": 200, "content": b"ok"})()
+
+        log_data = middleware._extract_devtrack_log_data(
+            request, response, datetime.now(timezone.utc)
+        )
+
+        assert log_data["path"] == "/api/widgets"
+        assert log_data["method"] == "GET"
+        assert log_data["status_code"] == 200
+        assert log_data["query_params"] == {"limit": ["10"]}
+        assert log_data["user_agent"] == "pytest"
+    finally:
+        if DevTrackDjangoMiddleware._db_instance is not None:
+            DevTrackDjangoMiddleware._db_instance.close()
+            DevTrackDjangoMiddleware._db_instance = None

--- a/tests/test_django_compatibility.py
+++ b/tests/test_django_compatibility.py
@@ -20,9 +20,10 @@ if not apps.ready:
     django.setup()
 
 
-def test_django_runtime_is_in_supported_ci_matrix():
-    """Verify CI exercises the declared supported Django versions."""
-    assert DJANGO_VERSION[:2] in {(4, 2), (5, 2)}
+def test_django_runtime_is_supported():
+    """Verify the installed Django runtime is within the supported range."""
+    assert DJANGO_VERSION[:2] >= (4, 2)
+    assert DJANGO_VERSION[:2] < (6, 0)
 
 
 def test_django_52_middleware_and_urls_load_with_configured_settings():

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,77 @@
+import ast
+import builtins
+import importlib
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FRAMEWORK_PACKAGES = {"django", "fastapi", "starlette", "httpx"}
+
+
+def _requirement_name(requirement: str) -> str:
+    match = re.match(r"[A-Za-z0-9_.-]+", requirement)
+    assert match, f"Invalid requirement: {requirement}"
+    return match.group(0).lower().replace("_", "-")
+
+
+def _requirement_names(requirements: list[str]) -> set[str]:
+    return {_requirement_name(requirement) for requirement in requirements}
+
+
+def test_pyproject_keeps_frameworks_optional():
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+
+    core_dependencies = _requirement_names(pyproject["project"]["dependencies"])
+    optional_dependencies = pyproject["project"]["optional-dependencies"]
+
+    assert FRAMEWORK_PACKAGES.isdisjoint(core_dependencies)
+    assert "fastapi" in _requirement_names(optional_dependencies["fastapi"])
+    assert "django" in _requirement_names(optional_dependencies["django"])
+    assert {"fastapi", "django"}.issubset(
+        _requirement_names(optional_dependencies["all"])
+    )
+
+
+def test_setup_py_keeps_frameworks_optional():
+    setup_tree = ast.parse((ROOT / "setup.py").read_text())
+    setup_call = next(
+        node
+        for node in ast.walk(setup_tree)
+        if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "setup"
+    )
+    setup_kwargs = {keyword.arg: keyword.value for keyword in setup_call.keywords}
+
+    install_requires = ast.literal_eval(setup_kwargs["install_requires"])
+    extras_require = ast.literal_eval(setup_kwargs["extras_require"])
+
+    assert FRAMEWORK_PACKAGES.isdisjoint(_requirement_names(install_requires))
+    assert "fastapi" in _requirement_names(extras_require["fastapi"])
+    assert "django" in _requirement_names(extras_require["django"])
+    assert {"fastapi", "django"}.issubset(_requirement_names(extras_require["all"]))
+
+
+def test_top_level_import_does_not_require_frameworks(monkeypatch):
+    for module_name in list(sys.modules):
+        if module_name == "devtrack_sdk" or module_name.startswith("devtrack_sdk."):
+            del sys.modules[module_name]
+
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        package_name = name.split(".", 1)[0]
+        if package_name in {"django", "fastapi", "starlette"}:
+            raise AssertionError(f"Unexpected framework import: {name}")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    package = importlib.import_module("devtrack_sdk")
+
+    assert package.__version__

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -30,13 +30,16 @@ def test_pyproject_keeps_frameworks_optional():
 
     core_dependencies = _requirement_names(pyproject["project"]["dependencies"])
     optional_dependencies = pyproject["project"]["optional-dependencies"]
+    classifiers = set(pyproject["project"]["classifiers"])
 
     assert FRAMEWORK_PACKAGES.isdisjoint(core_dependencies)
-    assert "fastapi" in _requirement_names(optional_dependencies["fastapi"])
-    assert "django" in _requirement_names(optional_dependencies["django"])
+    assert optional_dependencies["django"] == ["django>=4.0.0"]
+    assert optional_dependencies["fastapi"] == ["fastapi>=0.90"]
     assert {"fastapi", "django"}.issubset(
         _requirement_names(optional_dependencies["all"])
     )
+    assert "Framework :: Django :: 4.2" in classifiers
+    assert "Framework :: Django :: 5.2" in classifiers
 
 
 def test_setup_py_keeps_frameworks_optional():
@@ -50,11 +53,14 @@ def test_setup_py_keeps_frameworks_optional():
 
     install_requires = ast.literal_eval(setup_kwargs["install_requires"])
     extras_require = ast.literal_eval(setup_kwargs["extras_require"])
+    classifiers = ast.literal_eval(setup_kwargs["classifiers"])
 
     assert FRAMEWORK_PACKAGES.isdisjoint(_requirement_names(install_requires))
-    assert "fastapi" in _requirement_names(extras_require["fastapi"])
-    assert "django" in _requirement_names(extras_require["django"])
+    assert extras_require["django"] == ["django>=4.0.0"]
+    assert extras_require["fastapi"] == ["fastapi>=0.90"]
     assert {"fastapi", "django"}.issubset(_requirement_names(extras_require["all"]))
+    assert "Framework :: Django :: 4.2" in classifiers
+    assert "Framework :: Django :: 5.2" in classifiers
 
 
 def test_top_level_import_does_not_require_frameworks(monkeypatch):


### PR DESCRIPTION
- feat: add optional framework dependencies for FastAPI and Django integration
- :recycle: enhance Django support with compatibility for versions 4.2 and 5.2, update CI configuration, and add tests
- refactor: update Django runtime compatibility test to check supported version range
